### PR TITLE
docs: rebrand README for Brave, add attach-to-existing-instance guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-# Chrome DevTools MCP
+# Brave DevTools MCP
 
-[![npm chrome-devtools-mcp package](https://img.shields.io/npm/v/chrome-devtools-mcp.svg)](https://npmjs.org/package/chrome-devtools-mcp)
+> Fork of [ChromeDevTools/chrome-devtools-mcp](https://github.com/ChromeDevTools/chrome-devtools-mcp) ported to **Brave Browser**.
 
-`chrome-devtools-mcp` lets your coding agent (such as Gemini, Claude, Cursor or Copilot)
-control and inspect a live Chrome browser. It acts as a Model-Context-Protocol
+`brave-devtools-mcp` lets your coding agent (such as Claude, Cursor, Gemini or Copilot)
+control and inspect a live Brave browser. It acts as a Model-Context-Protocol
 (MCP) server, giving your AI coding assistant access to the full power of
-Chrome DevTools for reliable automation, in-depth debugging, and performance analysis.
+DevTools for reliable automation, in-depth debugging, and performance analysis.
 
 ## [Tool reference](./docs/tool-reference.md) | [Changelog](./CHANGELOG.md) | [Contributing](./CONTRIBUTING.md) | [Troubleshooting](./docs/troubleshooting.md) | [Design Principles](./docs/design-principles.md)
 
@@ -18,62 +18,32 @@ Chrome DevTools for reliable automation, in-depth debugging, and performance ana
   check browser console messages (with source-mapped stack traces).
 - **Reliable automation**. Uses
   [puppeteer](https://github.com/puppeteer/puppeteer) to automate actions in
-  Chrome and automatically wait for action results.
+  Brave and automatically wait for action results.
 
 ## Disclaimers
 
-`chrome-devtools-mcp` exposes content of the browser instance to the MCP clients
+`brave-devtools-mcp` exposes content of the browser instance to the MCP clients
 allowing them to inspect, debug, and modify any data in the browser or DevTools.
 Avoid sharing sensitive or personal information that you don't want to share with
 MCP clients.
 
-`chrome-devtools-mcp` officially supports Google Chrome and [Chrome for Testing](https://developer.chrome.com/blog/chrome-for-testing/) only.
-Other Chromium-based browsers may work, but this is not guaranteed, and you may encounter unexpected behavior. Use at your own discretion.
-We are committed to providing fixes and support for the latest version of [Extended Stable Chrome](https://chromiumdash.appspot.com/schedule).
-
 Performance tools may send trace URLs to the Google CrUX API to fetch real-user
-experience data. This helps provide a holistic performance picture by
-presenting field data alongside lab data. This data is collected by the [Chrome
-User Experience Report (CrUX)](https://developer.chrome.com/docs/crux). To disable
-this, run with the `--no-performance-crux` flag.
+experience data. To disable this, run with the `--no-performance-crux` flag.
 
-## **Usage statistics**
-
-Google collects usage statistics (such as tool invocation success rates, latency, and environment information) to improve the reliability and performance of Chrome DevTools MCP.
-
-Data collection is **enabled by default**. You can opt-out by passing the `--no-usage-statistics` flag when starting the server:
-
-```json
-"args": ["-y", "chrome-devtools-mcp@latest", "--no-usage-statistics"]
-```
-
-Google handles this data in accordance with the [Google Privacy Policy](https://policies.google.com/privacy).
-
-Google's collection of usage statistics for Chrome DevTools MCP is independent from the Chrome browser's usage statistics. Opting out of Chrome metrics does not automatically opt you out of this tool, and vice-versa.
-
-Collection is disabled if `CHROME_DEVTOOLS_MCP_NO_USAGE_STATISTICS` or `CI` env variables are set.
-
-## Update checks
-
-By default, the server periodically checks the npm registry for updates and logs a notification when a newer version is available.
-You can disable these update checks by setting the `CHROME_DEVTOOLS_MCP_NO_UPDATE_CHECKS` environment variable.
+Usage statistics from the upstream project are **disabled by default** in this fork.
+You can explicitly enable them with `--usage-statistics` if desired.
 
 ## Requirements
 
 - [Node.js](https://nodejs.org/) v20.19 or a newer [latest maintenance LTS](https://github.com/nodejs/Release#release-schedule) version.
-- [Chrome](https://www.google.com/chrome/) current stable version or newer.
+- [Brave Browser](https://brave.com/) current release version or newer.
 - [npm](https://www.npmjs.com/)
 
-## Local setup (Brave fork / Cursor)
+> **Note:** Do **not** use `chrome-devtools-mcp@latest` from npm — that installs Google's Chrome-oriented server. This fork is `brave-devtools-mcp`.
 
-This fork drives **Brave Browser**; the npm package name is **`brave-devtools-mcp`** (see `package.json`). Do **not** use `chrome-devtools-mcp@latest` from npm when you want *this* codebase—that installs Google's Chrome-oriented server, not this repository.
+## Setup
 
-### Prerequisites
-
-- **Node.js** v20.19 or newer (matches `engines` in `package.json`).
-- **Brave** installed in the default location for your OS, or set **`BRAVE_PATH`** to the browser binary.
-
-### Clone and build
+### 1. Clone and build
 
 ```sh
 git clone https://github.com/triuzzi/brave-devtools-mcp.git
@@ -84,73 +54,123 @@ npm run build
 
 Run `npm run build` again after `git pull` when you update the repo.
 
-### Cursor (or any MCP client using a local command)
+### 2. Configure your MCP client
 
-Point your MCP config at the **built** CLI with Node. Use an **absolute path** on your machine:
-
-```json
-"brave-devtools": {
-  "command": "node",
-  "args": [
-    "/absolute/path/to/brave-devtools-mcp/build/src/bin/brave-devtools-mcp.js"
-  ]
-}
-```
-
-In **Cursor**: **Settings → MCP → New MCP Server**, or add the same block to your user `mcp.json`. Restart Cursor after changing MCP configuration.
-
-Put optional server flags in `args` after the script path. To see what this build accepts:
-
-```sh
-node /absolute/path/to/brave-devtools-mcp/build/src/bin/brave-devtools-mcp.js --help
-```
-
-If Brave is not detected, set **`BRAVE_PATH`** in the MCP server `env` object. Example on macOS:
-
-```json
-"env": {
-  "BRAVE_PATH": "/Applications/Brave Browser.app/Contents/MacOS/Brave Browser"
-}
-```
-
-### Remote debugging (Brave)
-
-Use **`brave://inspect/#remote-debugging`** to enable remote debugging (not `chrome://inspect/...`).
-
-### Optional: `npx` from GitHub
-
-You can run straight from the repository without keeping a clone (needs network; a local build is usually better for daily use):
-
-```json
-"args": ["-y", "github:triuzzi/brave-devtools-mcp"]
-```
-
-## Getting started
-
-Add the following config to your MCP client:
+Point your MCP config at the built CLI. Use an **absolute path** on your machine:
 
 ```json
 {
   "mcpServers": {
-    "chrome-devtools": {
-      "command": "npx",
-      "args": ["-y", "chrome-devtools-mcp@latest"]
+    "brave-devtools": {
+      "command": "node",
+      "args": [
+        "/absolute/path/to/brave-devtools-mcp/build/src/bin/brave-devtools-mcp.js"
+      ]
     }
   }
 }
 ```
 
-> [!NOTE]
-> Using `chrome-devtools-mcp@latest` ensures that your MCP client will always use the latest version of the Chrome DevTools MCP server.
+This works with **Claude Code** (`~/.mcp.json`), **Cursor** (Settings → MCP → New MCP Server, or `mcp.json`), **VS Code Copilot**, and any other MCP client.
 
-If you are interested in doing only basic browser tasks, use the `--slim` mode:
+If Brave is not detected automatically, set `BRAVE_PATH`:
 
 ```json
 {
   "mcpServers": {
-    "chrome-devtools": {
-      "command": "npx",
-      "args": ["-y", "chrome-devtools-mcp@latest", "--slim", "--headless"]
+    "brave-devtools": {
+      "command": "node",
+      "args": ["/absolute/path/to/brave-devtools-mcp/build/src/bin/brave-devtools-mcp.js"],
+      "env": {
+        "BRAVE_PATH": "/Applications/Brave Browser.app/Contents/MacOS/Brave Browser"
+      }
+    }
+  }
+}
+```
+
+### 3. Choose your connection mode
+
+The server has two modes: **launch a new instance** (default) or **attach to your existing Brave window**.
+
+#### Mode A: Launch a new instance (default)
+
+With the basic config above, the server spawns a dedicated Brave instance with its own profile. Your existing Brave windows are untouched. This is the simplest mode — no extra setup needed.
+
+#### Mode B: Attach to your existing Brave window
+
+If you want the MCP server to control the Brave window you already have open (same tabs, cookies, logins), you need to start Brave with remote debugging enabled.
+
+**Step 1:** Quit Brave completely, then relaunch with the debugging flag:
+
+```sh
+# macOS
+open -a "Brave Browser" --args --remote-debugging-port=9222
+
+# Linux
+brave-browser --remote-debugging-port=9222
+
+# Windows
+"C:\Program Files\BraveSoftware\Brave-Browser\Application\brave.exe" --remote-debugging-port=9222
+```
+
+> **Tip:** To always start Brave with remote debugging, add `--remote-debugging-port=9222` to Brave's launch shortcut or shell alias so you never have to think about it again.
+
+**Step 2:** Add `--browserUrl` to your MCP config:
+
+```json
+{
+  "mcpServers": {
+    "brave-devtools": {
+      "command": "node",
+      "args": [
+        "/absolute/path/to/brave-devtools-mcp/build/src/bin/brave-devtools-mcp.js",
+        "--browserUrl", "http://127.0.0.1:9222"
+      ]
+    }
+  }
+}
+```
+
+Without `--browserUrl`, the server will always launch a new instance. With it, the server attaches to your running Brave instead.
+
+> **Warning:** The remote debugging port lets any application on your machine control the browser. Be mindful of sensitive websites while it's open.
+
+### All CLI options
+
+Run `--help` to see every flag:
+
+```sh
+node /absolute/path/to/brave-devtools-mcp/build/src/bin/brave-devtools-mcp.js --help
+```
+
+## Testing
+
+An integration test suite exercises all 29 MCP tools against a running Brave instance:
+
+```sh
+# Launch Brave with remote debugging
+open -a "Brave Browser" --args --remote-debugging-port=9222
+
+# Run all 36 test cases
+npm run test:brave
+```
+
+Tests cover navigation, snapshots, screenshots, script execution, input automation (click/fill/drag/upload), dialogs, console, network, emulation, performance tracing, memory snapshots, and Lighthouse audits.
+
+## Getting started
+
+If you are interested in only basic browser tasks, use `--slim` mode:
+
+```json
+{
+  "mcpServers": {
+    "brave-devtools": {
+      "command": "node",
+      "args": [
+        "/absolute/path/to/brave-devtools-mcp/build/src/bin/brave-devtools-mcp.js",
+        "--slim", "--headless"
+      ]
     }
   }
 }
@@ -523,13 +543,13 @@ Go to `Settings | AI | Manage MCP Servers` -> `+ Add` to [add an MCP Server](htt
 Enter the following prompt in your MCP Client to check if everything is working:
 
 ```
-Check the performance of https://developers.chrome.com
+Check the performance of https://example.com
 ```
 
-Your MCP client should open the browser and record a performance trace.
+Your MCP client should open Brave (or attach to the running instance) and record a performance trace.
 
 > [!NOTE]
-> The MCP server will start the browser automatically once the MCP client uses a tool that requires a running browser instance. Connecting to the Chrome DevTools MCP server on its own will not automatically start the browser.
+> The MCP server will start the browser automatically once the MCP client uses a tool that requires a running browser instance. Connecting to the Brave DevTools MCP server on its own will not automatically start the browser.
 
 ## Tools
 
@@ -577,7 +597,7 @@ If you run into any issues, checkout our [troubleshooting guide](./docs/troubles
 
 ## Configuration
 
-The Chrome DevTools MCP server supports the following configuration option:
+The Brave DevTools MCP server supports the following configuration options:
 
 <!-- BEGIN AUTO GENERATED OPTIONS -->
 
@@ -728,143 +748,26 @@ You can also run `npx chrome-devtools-mcp@latest --help` to see all available co
 
 ### User data directory
 
-`chrome-devtools-mcp` starts a Chrome's stable channel instance using the following user
+`brave-devtools-mcp` starts a Brave release channel instance using the following user
 data directory:
 
-- Linux / macOS: `$HOME/.cache/chrome-devtools-mcp/chrome-profile-$CHANNEL`
-- Windows: `%HOMEPATH%/.cache/chrome-devtools-mcp/chrome-profile-$CHANNEL`
+- Linux / macOS: `$HOME/.cache/brave-devtools-mcp/brave-profile-$CHANNEL`
+- Windows: `%HOMEPATH%/.cache/brave-devtools-mcp/brave-profile-$CHANNEL`
 
 The user data directory is not cleared between runs and shared across
-all instances of `chrome-devtools-mcp`. Set the `isolated` option to `true`
+all instances of `brave-devtools-mcp`. Set the `isolated` option to `true`
 to use a temporary user data dir instead which will be cleared automatically after
 the browser is closed.
 
-### Connecting to a running Chrome instance
+### Connecting to a running Brave instance
 
-By default, the Chrome DevTools MCP server will start a new Chrome instance with a dedicated profile. This might not be ideal in all situations:
+See [Mode B: Attach to your existing Brave window](#mode-b-attach-to-your-existing-brave-window) in the Setup section above.
 
-- If you would like to maintain the same application state when alternating between manual site testing and agent-driven testing.
-- When the MCP needs to sign into a website. Some accounts may prevent sign-in when the browser is controlled via WebDriver (the default launch mechanism for the Chrome DevTools MCP server).
-- If you're running your LLM inside a sandboxed environment, but you would like to connect to a Chrome instance that runs outside the sandbox.
+For VM-to-host port forwarding issues, see [`docs/troubleshooting.md`](./docs/troubleshooting.md#remote-debugging-between-virtual-machine-vm-and-host-fails).
 
-In these cases, start Chrome first and let the Chrome DevTools MCP server connect to it. There are two ways to do so:
+### Debugging on Android
 
-- **Automatic connection (available in Chrome 144)**: best for sharing state between manual and agent-driven testing.
-- **Manual connection via remote debugging port**: best when running inside a sandboxed environment.
-
-#### Automatically connecting to a running Chrome instance
-
-**Step 1:** Set up remote debugging in Chrome
-
-In Chrome (\>= M144), do the following to set up remote debugging:
-
-1.  Navigate to `chrome://inspect/#remote-debugging` to enable remote debugging.
-2.  Follow the dialog UI to allow or disallow incoming debugging connections.
-
-**Step 2:** Configure Chrome DevTools MCP server to automatically connect to a running Chrome Instance
-
-To connect the `chrome-devtools-mcp` server to the running Chrome instance, use
-`--autoConnect` command line argument for the MCP server.
-
-The following code snippet is an example configuration for gemini-cli:
-
-```json
-{
-  "mcpServers": {
-    "chrome-devtools": {
-      "command": "npx",
-      "args": ["chrome-devtools-mcp@latest", "--autoConnect"]
-    }
-  }
-}
-```
-
-**Step 3:** Test your setup
-
-Make sure your browser is running. Open gemini-cli and run the following prompt:
-
-```none
-Check the performance of https://developers.chrome.com
-```
-
-> [!NOTE]
-> The <code>autoConnect</code> option requires the user to start Chrome. If the user has multiple active profiles, the MCP server will connect to the default profile (as determined by Chrome). The MCP server has access to all open windows for the selected profile.
-
-The Chrome DevTools MCP server will try to connect to your running Chrome
-instance. It shows a dialog asking for user permission.
-
-Clicking **Allow** results in the Chrome DevTools MCP server opening
-[developers.chrome.com](http://developers.chrome.com) and taking a performance
-trace.
-
-#### Manual connection using port forwarding
-
-You can connect to a running Chrome instance by using the `--browser-url` option. This is useful if you are running the MCP server in a sandboxed environment that does not allow starting a new Chrome instance.
-
-Here is a step-by-step guide on how to connect to a running Chrome instance:
-
-**Step 1: Configure the MCP client**
-
-Add the `--browser-url` option to your MCP client configuration. The value of this option should be the URL of the running Chrome instance. `http://127.0.0.1:9222` is a common default.
-
-```json
-{
-  "mcpServers": {
-    "chrome-devtools": {
-      "command": "npx",
-      "args": [
-        "chrome-devtools-mcp@latest",
-        "--browser-url=http://127.0.0.1:9222"
-      ]
-    }
-  }
-}
-```
-
-**Step 2: Start the Chrome browser**
-
-> [!WARNING]
-> Enabling the remote debugging port opens up a debugging port on the running browser instance. Any application on your machine can connect to this port and control the browser. Make sure that you are not browsing any sensitive websites while the debugging port is open.
-
-Start the Chrome browser with the remote debugging port enabled. Make sure to close any running Chrome instances before starting a new one with the debugging port enabled. The port number you choose must be the same as the one you specified in the `--browser-url` option in your MCP client configuration.
-
-For security reasons, [Chrome requires you to use a non-default user data directory](https://developer.chrome.com/blog/remote-debugging-port) when enabling the remote debugging port. You can specify a custom directory using the `--user-data-dir` flag. This ensures that your regular browsing profile and data are not exposed to the debugging session.
-
-**macOS**
-
-```bash
-/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome --remote-debugging-port=9222 --user-data-dir=/tmp/chrome-profile-stable
-```
-
-**Linux**
-
-```bash
-/usr/bin/google-chrome --remote-debugging-port=9222 --user-data-dir=/tmp/chrome-profile-stable
-```
-
-**Windows**
-
-```bash
-"C:\Program Files\Google\Chrome\Application\chrome.exe" --remote-debugging-port=9222 --user-data-dir="%TEMP%\chrome-profile-stable"
-```
-
-**Step 3: Test your setup**
-
-After configuring the MCP client and starting the Chrome browser, you can test your setup by running a simple prompt in your MCP client:
-
-```
-Check the performance of https://developers.chrome.com
-```
-
-Your MCP client should connect to the running Chrome instance and receive a performance report.
-
-If you hit VM-to-host port forwarding issues, see the “Remote debugging between virtual machine (VM) and host fails” section in [`docs/troubleshooting.md`](./docs/troubleshooting.md#remote-debugging-between-virtual-machine-vm-and-host-fails).
-
-For more details on remote debugging, see the [Chrome DevTools documentation](https://developer.chrome.com/docs/devtools/remote-debugging/).
-
-### Debugging Chrome on Android
-
-Please consult [these instructions](./docs/debugging-android.md).
+Please consult [these instructions](./docs/debugging-android.md) (originally written for Chrome, but applicable to any Chromium browser).
 
 ## Known limitations
 


### PR DESCRIPTION
## Summary

Supersedes #3 — takes @SirGian99's local setup contribution and extends it into a full README rebrand.

- Replace all Chrome branding (header, disclaimers, requirements, concepts, user data dirs)
- Add structured Setup section: clone/build → MCP client config → connection modes
- **Document Mode A vs Mode B** — the key question users hit: "launch new instance" vs "attach to my existing Brave window with `--browserUrl`"
- Add tip for always starting Brave with `--remote-debugging-port=9222`
- Add Testing section pointing to `npm run test:brave`
- Disable usage statistics by default
- Remove 100+ lines of redundant Chrome-specific connection instructions, replaced with cross-references to Setup

## Test plan

- [x] All internal links resolve
- [x] JSON config examples are valid
- [x] Shell commands match actual binary paths