### PR TITLE
feat: rename npm package to brave-mcp

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,11 +1,11 @@
 {
-  "name": "brave-devtools-mcp",
+  "name": "brave-mcp",
   "version": "0.1.0",
   "description": "Reliable automation, in-depth debugging, and performance analysis in Brave using DevTools and Puppeteer",
   "mcpServers": {
     "brave-devtools": {
       "command": "npx",
-      "args": ["brave-devtools-mcp@latest"]
+      "args": ["brave-mcp@latest"]
     }
   }
 }

--- a/.mcp.json
+++ b/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "brave-devtools": {
       "command": "npx",
-      "args": ["brave-devtools-mcp@latest"]
+      "args": ["brave-mcp@latest"]
     }
   }
 }

--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
-# Brave DevTools MCP
+# Brave MCP
 
 > Fork of [ChromeDevTools/chrome-devtools-mcp](https://github.com/ChromeDevTools/chrome-devtools-mcp) ported to **Brave Browser**.
+>
+> npm: `brave-mcp` · repo: `triuzzi/brave-devtools-mcp`
 
-`brave-devtools-mcp` lets your coding agent (such as Claude, Cursor, Gemini or Copilot)
+`brave-mcp` lets your coding agent (such as Claude, Cursor, Gemini or Copilot)
 control and inspect a live Brave browser. It acts as a Model-Context-Protocol
 (MCP) server, giving your AI coding assistant access to the full power of
 DevTools for reliable automation, in-depth debugging, and performance analysis.
@@ -39,11 +41,26 @@ You can explicitly enable them with `--usage-statistics` if desired.
 - [Brave Browser](https://brave.com/) current release version or newer.
 - [npm](https://www.npmjs.com/)
 
-> **Note:** Do **not** use `chrome-devtools-mcp@latest` from npm — that installs Google's Chrome-oriented server. This fork is `brave-devtools-mcp`.
+> **Note:** Do **not** use `chrome-devtools-mcp@latest` from npm — that installs Google's Chrome-oriented server. This fork is `brave-mcp`.
 
 ## Setup
 
-### 1. Clone and build
+### Quick start (via npm)
+
+```json
+{
+  "mcpServers": {
+    "brave-devtools": {
+      "command": "npx",
+      "args": ["-y", "brave-mcp@latest"]
+    }
+  }
+}
+```
+
+Add this to your MCP client config and you're done. Works with **Claude Code** (`~/.mcp.json`), **Cursor** (Settings → MCP), **VS Code Copilot**, and any other MCP client.
+
+### From source (for development)
 
 ```sh
 git clone https://github.com/triuzzi/brave-devtools-mcp.git
@@ -54,9 +71,7 @@ npm run build
 
 Run `npm run build` again after `git pull` when you update the repo.
 
-### 2. Configure your MCP client
-
-Point your MCP config at the built CLI. Use an **absolute path** on your machine:
+Then point your MCP config at the built CLI with an **absolute path**:
 
 ```json
 {
@@ -122,10 +137,23 @@ brave-browser --remote-debugging-port=9222
 {
   "mcpServers": {
     "brave-devtools": {
+      "command": "npx",
+      "args": ["-y", "brave-mcp@latest", "--browserUrl", "http://localhost:9222"]
+    }
+  }
+}
+```
+
+Or if running from source:
+
+```json
+{
+  "mcpServers": {
+    "brave-devtools": {
       "command": "node",
       "args": [
         "/absolute/path/to/brave-devtools-mcp/build/src/bin/brave-devtools-mcp.js",
-        "--browserUrl", "http://127.0.0.1:9222"
+        "--browserUrl", "http://localhost:9222"
       ]
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,9 +1,10 @@
 {
-  "name": "brave-devtools-mcp",
+  "name": "brave-mcp",
   "version": "0.1.0",
   "description": "MCP server for Brave DevTools",
   "type": "module",
   "bin": {
+    "brave-mcp": "./build/src/bin/brave-devtools-mcp.js",
     "brave-devtools-mcp": "./build/src/bin/brave-devtools-mcp.js",
     "brave-devtools": "./build/src/bin/brave-devtools.js"
   },

--- a/server.json
+++ b/server.json
@@ -1,10 +1,10 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
-  "name": "io.github.nichochar/brave-devtools-mcp",
-  "title": "Brave DevTools MCP",
-  "description": "MCP server for Brave DevTools",
+  "name": "io.github.triuzzi/brave-mcp",
+  "title": "Brave MCP",
+  "description": "MCP server for Brave Browser DevTools",
   "repository": {
-    "url": "https://github.com/nichochar/brave-devtools-mcp",
+    "url": "https://github.com/triuzzi/brave-devtools-mcp",
     "source": "github"
   },
   "version": "0.1.0",
@@ -12,7 +12,7 @@
     {
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
-      "identifier": "brave-devtools-mcp",
+      "identifier": "brave-mcp",
       "version": "0.1.0",
       "transport": {
         "type": "stdio"

--- a/src/bin/check-latest-version.ts
+++ b/src/bin/check-latest-version.ts
@@ -13,7 +13,7 @@ const cachePath = process.argv[2];
 if (cachePath) {
   try {
     const response = await fetch(
-      'https://registry.npmjs.org/brave-devtools-mcp/latest',
+      'https://registry.npmjs.org/brave-mcp/latest',
     );
     const data = response.ok ? await response.json() : null;
 


### PR DESCRIPTION
## Summary

- Rename npm package from `brave-devtools-mcp` to `brave-mcp` (name is available)
- Add `brave-mcp` bin alias so `npx brave-mcp@latest` works
- Update README with npx quick start as the primary setup method
- Update all config files (server.json, .mcp.json, plugin.json)

## After merge

Publish to npm:
```sh
npm login
npm publish --access public
```

Then this works everywhere:
```json
{
  "mcpServers": {
    "brave-devtools": {
      "command": "npx",
      "args": ["-y", "brave-mcp@latest"]
    }
  }
}
```

Or to attach to an existing Brave instance (started with `--remote-debugging-port=9222`):
```json
{
  "mcpServers": {
    "brave-devtools": {
      "command": "npx",
      "args": ["-y", "brave-mcp@latest", "--browserUrl", "http://localhost:9222"]
    }
  }
}
```

## Test plan

- [x] `npm run build` compiles cleanly
- [x] `--help` shows correct binary names