### PR TITLE
chore: sync upstream + 0.2.1 patch

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,36 +1,36 @@
-# Chrome DevTools CLI
+# Brave DevTools CLI
 
-The `chrome-devtools-mcp` package includes an **experimental** CLI interface that allows you to interact with the browser directly from your terminal. This is particularly useful for debugging or when you want an agent to generate scripts that automate browser actions.
+The `brave-devtools-mcp` package includes an **experimental** CLI interface that allows you to interact with the browser directly from your terminal. This is particularly useful for debugging or when you want an agent to generate scripts that automate browser actions.
 
 ## Getting started
 
-Install the package globally to make the `chrome-devtools` command available:
+Install the package globally to make the `brave-devtools` command available:
 
 ```sh
-npm i chrome-devtools-mcp@latest -g
-chrome-devtools status # check if install worked.
+npm i brave-devtools-mcp@latest -g
+brave-devtools status # check if install worked.
 ```
 
 ## How it works
 
-The CLI acts as a client to a background `chrome-devtools-mcp` daemon (uses Unix sockets on Linux/Mac and named pipes on Windows).
+The CLI acts as a client to a background `brave-devtools-mcp` daemon (uses Unix sockets on Linux/Mac and named pipes on Windows).
 
 - **Automatic Start**: The first time you call a tool (e.g., `list_pages`), the CLI automatically starts the MCP server and the browser in the background if they aren't already running.
 - **Persistence**: The same background instance is reused for subsequent commands, preserving the browser state (open pages, cookies, etc.).
-- **Manual Control**: You can explicitly manage the background process using `start`, `stop`, and `status`. The `start` command forwards all subsequent arguments to the underlying MCP server (e.g., `--headless`, `--userDataDir`) but not all args are supported. Run `chrome-devtools start --help` for supported args. Headless is enabled by default. Isolated is enabled by default unless `--userDataDir` is provided.
+- **Manual Control**: You can explicitly manage the background process using `start`, `stop`, and `status`. The `start` command forwards all subsequent arguments to the underlying MCP server (e.g., `--headless`, `--userDataDir`) but not all args are supported. Run `brave-devtools start --help` for supported args. Headless is enabled by default. Isolated is enabled by default unless `--userDataDir` is provided.
 
 ```sh
 # Check if the daemon is running
-chrome-devtools status
+brave-devtools status
 
 # Navigate the current page to a URL
-chrome-devtools navigate_page "https://google.com"
+brave-devtools navigate_page url --url "https://google.com"
 
 # Take a screenshot and save it to a file
-chrome-devtools take_screenshot --filePath screenshot.png
+brave-devtools take_screenshot --filePath screenshot.png
 
 # Stop the background daemon when finished
-chrome-devtools stop
+brave-devtools stop
 ```
 
 ## Command Usage
@@ -38,7 +38,7 @@ chrome-devtools stop
 The CLI supports all tools available in the [Tool reference](./tool-reference.md).
 
 ```sh
-chrome-devtools <tool> [arguments] [flags]
+brave-devtools <tool> [arguments] [flags]
 ```
 
 - **Required Arguments**: Passed as positional arguments.
@@ -49,25 +49,25 @@ chrome-devtools <tool> [arguments] [flags]
 **New Page and Navigation:**
 
 ```sh
-chrome-devtools new_page "https://example.com"
-chrome-devtools navigate_page "https://web.dev" --type url
+brave-devtools new_page "https://example.com"
+brave-devtools navigate_page url --url "https://web.dev"
 ```
 
 **Interaction:**
 
 ```sh
 # Click an element by its UID from a snapshot
-chrome-devtools click "element-uid-123"
+brave-devtools click "element-uid-123"
 
 # Fill a form field
-chrome-devtools fill "input-uid-456" "search query"
+brave-devtools fill "input-uid-456" "search query"
 ```
 
 **Analysis:**
 
 ```sh
 # Run a Lighthouse audit (defaults to navigation mode)
-chrome-devtools lighthouse_audit --mode snapshot
+brave-devtools lighthouse_audit --mode snapshot
 ```
 
 ## Output format
@@ -75,7 +75,7 @@ chrome-devtools lighthouse_audit --mode snapshot
 By default, the CLI outputs a human-readable summary of the tool's result. For programmatic use, you can request raw JSON:
 
 ```sh
-chrome-devtools list_pages --output-format=json
+brave-devtools list_pages --output-format=json
 ```
 
 ## Troubleshooting
@@ -83,13 +83,13 @@ chrome-devtools list_pages --output-format=json
 If the CLI hangs or fails to connect, try stopping the background process:
 
 ```sh
-chrome-devtools stop
+brave-devtools stop
 ```
 
 For more verbose logs, set the `DEBUG` environment variable:
 
 ```sh
-DEBUG=* chrome-devtools list_pages
+DEBUG=* brave-devtools list_pages
 ```
 
 ## CLI generation
@@ -97,5 +97,5 @@ DEBUG=* chrome-devtools list_pages
 Implemented in `scripts/generate-cli.ts`. Some commands are excluded from CLI
 generation such as `wait_for` and `fill_form`.
 
-`chrome-devtools-mcp` args are also filtered in `src/bin/chrome-devtools.ts`
+`brave-devtools-mcp` args are also filtered in `src/bin/brave-devtools.ts`
 because not all args make sense in a CLI interface.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "brave-mcp",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "brave-mcp",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "Apache-2.0",
       "bin": {
         "brave-devtools": "build/src/bin/brave-devtools.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "brave-mcp",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "MCP server for Brave DevTools",
   "type": "module",
   "bin": {

--- a/src/version.ts
+++ b/src/version.ts
@@ -4,4 +4,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-export const VERSION = '0.1.0';
+export const VERSION = '0.2.1';


### PR DESCRIPTION
## Summary

- Sync fork with upstream `ChromeDevTools/chrome-devtools-mcp` (10 new commits rebased below our Brave commits)
- Rebrand `docs/cli.md` for Brave (was still entirely Chrome-branded — missed in the initial port)
- Fix `src/version.ts` drift (was hardcoded at `0.1.0` while package was `0.2.0`, causing the CLI to report the wrong version and nag local builds with a false update prompt) by bumping it alongside `package.json` to `0.2.1`

## Upstream commits pulled in

- `0331f6a` chore: implement memory snapshot information (#1874)
- `ea57e86` fix: ignore unmapped PerformanceIssue events (#1852)
- `2f458c1` fix(network): trailing data in Network redirect chain (#1880)
- `49f46b3` chore: amend security guidelines (#1890)
- `3f0cf10` fix: avoid showing update notification for local builds (#1889) — added `semver` dep
- `796d6f2` docs: document network response and request extensions (#1887)
- `54cfc7e` chore(deps-dev): bump protobufjs 7.5.4 → 7.5.5 (#1885)
- `e102a43` test: try things to reduce flakiness (#1879)
- `6ba1816` test: add debug logs when running GitHub actions in debug (#1878)
- `0287486` chore: minor fixes to build and evals (#1875)

> Note: the three existing Brave commits (port, README rebrand, 0.2.0) are included in this PR with new SHAs because they were rebased onto the new upstream. Merge with **rebase** to keep a clean linear history.

## Verified

- `--usage-statistics` still defaults to `false`
- Bins still `brave-mcp` / `brave-devtools-mcp` / `brave-devtools`
- `tsc` passes
- CLI smoke test on Brave: `start`, `status`, `list_pages`, `navigate_page url --url`, `evaluate_script`, `take_screenshot`, `list_console_messages`, `list_network_requests`, `--output-format=json`, `stop`
- MCP smoke test (first 10 tools of `tests/e2e/brave-integration.test.mjs`) passes against live Brave — further tests OOM'd due to event volume from the user's real browser, not a regression

## Test plan

- [ ] CI green
- [ ] After merge, tag `v0.2.1` and create GitHub pre-release