### PR TITLE
chore: release 0.3.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "brave-mcp",
-  "version": "0.1.0",
+  "version": "0.3.0",
   "description": "Reliable automation, in-depth debugging, and performance analysis in Brave using DevTools and Puppeteer",
   "mcpServers": {
     "brave-devtools": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "brave-mcp",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "brave-mcp",
-      "version": "0.2.2",
+      "version": "0.3.0",
       "license": "Apache-2.0",
       "bin": {
         "brave-devtools": "build/src/bin/brave-devtools.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "brave-mcp",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "description": "MCP server for Brave DevTools",
   "type": "module",
   "bin": {

--- a/scripts/eval_gemini.ts
+++ b/scripts/eval_gemini.ts
@@ -101,7 +101,7 @@ async function runSingleScenario(
     // Path to the compiled MCP server
     const serverPath = path.join(
       ROOT_DIR,
-      'build/src/bin/chrome-devtools-mcp.js',
+      'build/src/bin/brave-devtools-mcp.js',
     );
     if (!fs.existsSync(serverPath)) {
       throw new Error(

--- a/scripts/generate-cli.ts
+++ b/scripts/generate-cli.ts
@@ -20,11 +20,11 @@ const OUTPUT_PATH = path.join(
 );
 
 async function fetchTools() {
-  console.log('Connecting to chrome-devtools-mcp to fetch tools...');
+  console.log('Connecting to brave-devtools-mcp to fetch tools...');
   // Use the local build of the server
   const serverPath = path.join(
     import.meta.dirname,
-    '../build/src/bin/chrome-devtools-mcp.js',
+    '../build/src/bin/brave-devtools-mcp.js',
   );
 
   const transport = new StdioClientTransport({

--- a/scripts/generate-docs.ts
+++ b/scripts/generate-docs.ts
@@ -28,7 +28,7 @@ async function measureServer(args: string[]) {
   // 1. Connect to your actual MCP server
   const transport = new StdioClientTransport({
     command: 'node',
-    args: ['./build/src/bin/chrome-devtools-mcp.js', ...args], // Point to your built MCP server
+    args: ['./build/src/bin/brave-devtools-mcp.js', ...args], // Point to your built MCP server
   });
 
   const client = new Client(

--- a/server.json
+++ b/server.json
@@ -7,13 +7,13 @@
     "url": "https://github.com/triuzzi/brave-devtools-mcp",
     "source": "github"
   },
-  "version": "0.2.0",
+  "version": "0.3.0",
   "packages": [
     {
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "brave-mcp",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "transport": {
         "type": "stdio"
       },

--- a/src/version.ts
+++ b/src/version.ts
@@ -4,4 +4,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-export const VERSION = '0.2.2';
+export const VERSION = '0.3.0';

--- a/tests/check-for-updates.test.ts
+++ b/tests/check-for-updates.test.ts
@@ -31,8 +31,8 @@ describe('checkForUpdates', () => {
     resetUpdateCheckFlagForTesting();
   });
 
-  it('does nothing if CHROME_DEVTOOLS_MCP_NO_UPDATE_CHECKS is set', async () => {
-    process.env['CHROME_DEVTOOLS_MCP_NO_UPDATE_CHECKS'] = 'true';
+  it('does nothing if BRAVE_DEVTOOLS_MCP_NO_UPDATE_CHECKS is set', async () => {
+    process.env['BRAVE_DEVTOOLS_MCP_NO_UPDATE_CHECKS'] = 'true';
 
     const warnStub = sinon.stub(console, 'warn');
     const spawnStub = sinon.stub(child_process, 'spawn');
@@ -46,7 +46,7 @@ describe('checkForUpdates', () => {
     assert.ok(readFileStub.notCalled);
     assert.ok(statStub.notCalled);
 
-    delete process.env['CHROME_DEVTOOLS_MCP_NO_UPDATE_CHECKS'];
+    delete process.env['BRAVE_DEVTOOLS_MCP_NO_UPDATE_CHECKS'];
   });
 
   it('notifies if cache exists and version is different', async () => {

--- a/tests/third_party_notices.test.js.snapshot
+++ b/tests/third_party_notices.test.js.snapshot
@@ -1,31 +1,4 @@
 exports[`THIRD_PARTY_NOTICES > matches snapshot if exists 1`] = `
-Name: urlpattern-polyfill
-URL: https://github.com/kenchris/urlpattern-polyfill
-Version: <VERSION>
-License: MIT
-
-Copyright 2020 Intel Corporation
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
-
--------------------- DEPENDENCY DIVIDER --------------------
-
 Name: core-js
 URL: https://core-js.io
 Version: <VERSION>
@@ -319,30 +292,6 @@ Copyright 2018 Stefan Penner
 Permission to use, copy, modify, and/or distribute this software for any purpose with or without fee is hereby granted, provided that the above copyright notice and this permission notice appear in all copies.
 
 THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
-
-
--------------------- DEPENDENCY DIVIDER --------------------
-
-Name: semver
-URL: git+https://github.com/npm/node-semver.git
-Version: <VERSION>
-License: ISC
-
-The ISC License
-
-Copyright (c) Isaac Z. Schlueter and Contributors
-
-Permission to use, copy, modify, and/or distribute this software for any
-purpose with or without fee is hereby granted, provided that the above
-copyright notice and this permission notice appear in all copies.
-
-THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
-WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
-MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
-ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
-WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
-ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
-IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 
 -------------------- DEPENDENCY DIVIDER --------------------
@@ -879,6 +828,30 @@ Name: @puppeteer/browsers
 URL: https://github.com/puppeteer/puppeteer/tree/main/packages/browsers
 Version: <VERSION>
 License: Apache-2.0
+
+-------------------- DEPENDENCY DIVIDER --------------------
+
+Name: semver
+URL: git+https://github.com/npm/node-semver.git
+Version: <VERSION>
+License: ISC
+
+The ISC License
+
+Copyright (c) Isaac Z. Schlueter and Contributors
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
+IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
 
 -------------------- DEPENDENCY DIVIDER --------------------
 

--- a/tests/tools/pagesNavigateAllowlist.test.ts
+++ b/tests/tools/pagesNavigateAllowlist.test.ts
@@ -7,7 +7,7 @@
 import assert from 'node:assert';
 import {describe, it} from 'node:test';
 
-import type {ParsedArguments} from '../../src/bin/chrome-devtools-mcp-cli-options.js';
+import type {ParsedArguments} from '../../src/bin/brave-devtools-mcp-cli-options.js';
 import {navigatePage} from '../../src/tools/pages.js';
 import {serverHooks} from '../server.js';
 import {withMcpContext} from '../utils.js';

--- a/tests/tools/screencast.test.ts
+++ b/tests/tools/screencast.test.ts
@@ -9,7 +9,7 @@ import {describe, it, afterEach} from 'node:test';
 
 import sinon from 'sinon';
 
-import type {ParsedArguments} from '../../src/bin/chrome-devtools-mcp-cli-options.js';
+import type {ParsedArguments} from '../../src/bin/brave-devtools-mcp-cli-options.js';
 import {startScreencast, stopScreencast} from '../../src/tools/screencast.js';
 import {withMcpContext} from '../utils.js';
 

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -350,7 +350,7 @@ export function getMockBrowser(): Browser {
   } as Browser;
 }
 
-export const CLI_PATH = path.resolve('build/src/bin/chrome-devtools.js');
+export const CLI_PATH = path.resolve('build/src/bin/brave-devtools.js');
 
 export async function runCli(
   args: string[],


### PR DESCRIPTION
## Summary

Bumps to 0.3.0 to mark the upstream sync that brought in chrome-devtools-mcp 0.21.0 → 0.23.0. The minor bump reflects the new functionality landing in this release rather than just a patch.

Files updated:
- `package.json` and `package-lock.json` — npm publish version
- `src/version.ts` — runtime `VERSION` constant
- `server.json` — MCP registry entry (top-level + npm package version)
- `.claude-plugin/plugin.json` — Claude plugin manifest (was lagging at 0.1.0)

## What's new since 0.2.2

Headline features pulled in from upstream:
- MCP client roots support
- Per-session daemon scoping (`--sessionId`)
- WebM screencast format and configurable ffmpeg path
- Experimental navigation allowlist
- Chrome extensions debugging tools
- In-page tool output preprocessing
- Grouping of consecutive identical console messages

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run build` passes (on top of #8)
- [x] `npm test` passes locally with Brave installed

> **Note:** Depends on #8 — merge that first so the build is green on `main`. After #8 squash-lands, this branch rebases to a single commit cleanly.