### PR TITLE
fix: protocolTimeout for heavy pages + attach-mode arg cleanup

### DIFF
--- a/src/bin/brave-devtools.ts
+++ b/src/bin/brave-devtools.ts
@@ -97,12 +97,29 @@ y.command(
     if (isDaemonRunning(argv.sessionId)) {
       await stopDaemon(argv.sessionId);
     }
-    // Defaults but we do not want to affect the yargs conflict resolution.
-    if (argv.isolated === undefined && argv.userDataDir === undefined) {
-      argv.isolated = true;
-    }
-    if (argv.headless === undefined) {
-      argv.headless = true;
+    // Defaults only apply to *spawn* mode. Skip / clear them when
+    // attaching to an existing browser, otherwise `status` shows
+    // misleading args like `--browserUrl X --headless --isolated`
+    // together (the runtime ignores headless/isolated under attach,
+    // but storing them anyway is a footgun if the resolver order ever
+    // changes — and confuses anyone reading `status` output).
+    const isAttachMode =
+      argv.browserUrl !== undefined ||
+      argv.wsEndpoint !== undefined ||
+      argv.autoConnect === true;
+    if (isAttachMode) {
+      // Strip spawn-mode flags so serializeArgs doesn't emit them.
+      // Headless has `default: true` in the CLI override, so this is
+      // necessary even when the user didn't pass `--headless`.
+      delete argv.headless;
+      delete argv.isolated;
+    } else {
+      if (argv.isolated === undefined && argv.userDataDir === undefined) {
+        argv.isolated = true;
+      }
+      if (argv.headless === undefined) {
+        argv.headless = true;
+      }
     }
     const args = serializeArgs(cliOptions, argv);
     await start(args, argv.sessionId);

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -21,6 +21,17 @@ let browser: Browser | undefined;
 
 export type Channel = 'release' | 'beta' | 'nightly' | 'dev';
 
+// Heavy pages (e.g. Studio module dev bundles >100MB) cannot ack
+// `Network.enable` and other auto-attached domain calls within
+// puppeteer's default 180s. Once that fires, the CDP connection is
+// marked dead and every subsequent call throws — only daemon restart
+// recovers. Bumping the ceiling to 10min covers realistic loads;
+// override via env for power users.
+const PROTOCOL_TIMEOUT_MS = parseInt(
+  process.env.BRAVE_DEVTOOLS_PROTOCOL_TIMEOUT_MS ?? '600000',
+  10,
+);
+
 function makeTargetFilter(enableExtensions = false) {
   const ignoredPrefixes = new Set([
     'chrome://',
@@ -189,6 +200,7 @@ export async function ensureBrowserConnected(options: {
     targetFilter: makeTargetFilter(enableExtensions),
     defaultViewport: null,
     handleDevToolsAsPage: true,
+    protocolTimeout: PROTOCOL_TIMEOUT_MS,
   };
 
   let autoConnect = false;
@@ -340,6 +352,7 @@ export async function launch(options: McpLaunchOptions): Promise<Browser> {
       acceptInsecureCerts: options.acceptInsecureCerts,
       handleDevToolsAsPage: true,
       enableExtensions: options.enableExtensions,
+      protocolTimeout: PROTOCOL_TIMEOUT_MS,
     });
     if (options.logFile) {
       browser.process()?.stderr?.pipe(options.logFile);


### PR DESCRIPTION
## Summary

Two reliability fixes for real-world failures hit during a Brightcove Studio dev session:

### 1. `protocolTimeout` raised from puppeteer's 180s default to 10min

Heavy pages (Studio module dev bundles ~160MB JS) cannot ack `Network.enable` and other auto-attached CDP calls within 180s. Once the timeout fires, puppeteer marks the connection dead and every subsequent call throws `Network.enable timed out` — only daemon restart recovers.

Bumped to 600s on both `puppeteer.connect()` and `puppeteer.launch()`. Env-overridable via `BRAVE_DEVTOOLS_PROTOCOL_TIMEOUT_MS`.

### 2. Attach-mode `start` no longer emits spawn-only flags

`brave-devtools start --browserUrl http://127.0.0.1:9222` was producing args `--browser-url X --headless --isolated`. Runtime ignored them, but `status` showed misleading output. Detect attach mode and strip spawn-only flags before serializing.

## Smoke test

```
attach: args=["--browser-url","http://127.0.0.1:9222","--category-..."]    # clean
spawn:  args=["--headless","--isolated","--category-..."]                  # defaults still apply
```

## Out of scope (separate PRs)

- Per-tty daemon cleanup (10× stale daemons observed)
- Hang recovery / health probe (`Network.enable` wedge has no auto-recovery)

## Companion upstream PR

Mirror submitted to upstream chrome-devtools-mcp: ChromeDevTools/chrome-devtools-mcp#2009.

🤖 Generated with [Claude Code](https://claude.com/claude-code)