### PR TITLE
ci: repair release pipeline for the brave-mcp fork

### DIFF
--- a/.github/workflows/publish-to-npm-on-tag.yml
+++ b/.github/workflows/publish-to-npm-on-tag.yml
@@ -44,20 +44,8 @@ jobs:
         env:
           NODE_ENV: 'production'
 
-      - name: Publish chrome-devtools-mcp
+      - name: Publish brave-mcp
         run: |
-          npm publish --provenance --access public
-
-      - name: Publish chrome-devtools
-        run: |
-          node --input-type=module --eval '
-            import * as fs from "node:fs/promises";
-            const json = await fs.readFile("package.json", "utf8");
-            const pkg = JSON.parse(json);
-            pkg.name = "chrome-devtools";
-            await fs.writeFile("package.json", JSON.stringify(pkg, null, 2) + "\n");
-          '
-          echo 'This is the **Chrome DevTools for agents** package. Docs: https://github.com/ChromeDevTools/chrome-devtools-mcp' > README.md
           npm publish --provenance --access public
 
   publish-to-mcp-registry:

--- a/scripts/verify-npm-package.mjs
+++ b/scripts/verify-npm-package.mjs
@@ -5,6 +5,11 @@
  */
 
 import {execSync} from 'node:child_process';
+import {readFileSync} from 'node:fs';
+
+// Resolve the published package name from package.json so this keeps working
+// across the Brave fork rename (this was hardcoded to 'chrome-devtools-mcp').
+const packageName = JSON.parse(readFileSync('package.json', 'utf8')).name;
 
 // Checks that the select build files are present using `npm publish --dry-run`.
 function verifyPackageContents() {
@@ -14,7 +19,7 @@ function verifyPackageContents() {
     });
     // skip non-JSON output from prepare.
     const data = JSON.parse(output.substring(output.indexOf('{')));
-    const files = data['chrome-devtools-mcp'].files.map(f => f.path);
+    const files = data[packageName].files.map(f => f.path);
     // Check some important files.
     const requiredPaths = [
       'build/src/index.js',


### PR DESCRIPTION
Two pre-existing fork bugs (inherited from the upstream port) that block a clean release:

1. **`verify-npm-package.mjs`** hardcoded the upstream package key `chrome-devtools-mcp` → `data['chrome-devtools-mcp'].files` was `undefined` for `brave-mcp`, failing the pre-release "Verify npm package" check on every release. Now resolves the name from `package.json`.
2. **`publish-to-npm-on-tag.yml`** had an upstream-only "Publish chrome-devtools" step (renames the package to `chrome-devtools` and publishes it). The fork doesn't own that npm name, so it failed *after* the real publish — taking the job down and skipping the MCP-registry publish. Removed.

Unblocks the `brave-mcp@1.2.0` release (PR #18).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
