### PR TITLE
fix(ci): stop the MCP registry publish from firing on tag push

### DIFF
--- a/.github/workflows/publish-to-mcp-registry-on-tag.yml
+++ b/.github/workflows/publish-to-mcp-registry-on-tag.yml
@@ -1,9 +1,6 @@
 name: publish-to-mcp-registry-on-tag
 
 on:
-  push:
-    tags:
-      - 'v*'
   workflow_dispatch:
   workflow_call:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,6 +44,10 @@ green and merged, dispatch the `Release` workflow from `main`. It verifies the
 full package, creates the matching `v<version>` GitHub release, publishes
 `brave-mcp` to npm with provenance, and publishes the MCP Registry entry.
 
+Do not create the tag or the GitHub release by hand. The workflow owns both, and
+it refuses to run when either already exists, so a hand-made release has to be
+deleted before a release can go out.
+
 ### How to update the Lighthouse dependency
 
 - Update the Lighthouse version in package.json and run `npm install`. The npm version is currently used for types.


### PR DESCRIPTION
`publish-to-mcp-registry-on-tag` triggered on `push: tags: v*`. That trigger has no useful outcome in this fork's release flow:

- the `Release` workflow (`publish-to-npm-on-tag.yml`) already invokes it via `workflow_call`, ordered **after** `npm publish` — the only point at which the npm package its "Wait for npm package availability" step polls for actually exists
- when the pipeline then publishes the draft release, GitHub pushes the tag, which fires this workflow a **second** time — a duplicate registry publish
- when a `v*` tag reaches the repo any other way, it fires **early**, polls npm for 5 minutes, and fails

The third case is what produced [this failure on v1.8.0](https://github.com/triuzzi/brave-devtools-mcp/actions/runs/33250529730): the tag was created by hand, so the workflow started waiting for `brave-mcp@1.8.0` before anything had published it.

Dropping the trigger leaves `workflow_call` (the pipeline) and `workflow_dispatch` (publishing a registry entry by hand, e.g. to recover a release). The wait loop stays as a guard against registry propagation lag.

Also documents in `CONTRIBUTING.md` that the tag and release belong to the workflow — `verify-release` refuses to run when either already exists.

### Note on v1.8.0

`brave-mcp@1.8.0` is **not on npm** and has **no MCP Registry entry**; the v1.8.0 tag and GitHub release exist because I created them by hand instead of dispatching `Release`. This PR does not change that — see the discussion on the release.

Co-Authored-By: Claude <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)