### PR TITLE
feat: discover Brave Origin on Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -990,6 +990,11 @@ Check the performance of https://developers.chrome.com
 The Brave DevTools MCP server will try to connect to your running Brave
 instance. It shows a dialog asking for user permission.
 
+On Linux, automatic connection discovers both the standard `Brave-Browser`
+profile and the `Brave-Origin` profile used by Manjaro's `brave-origin-bin`
+package. When both profiles exist, it selects the one with an active remote
+debugging port.
+
 Clicking **Allow** results in the Brave DevTools MCP server opening
 [developers.chrome.com](http://developers.chrome.com) and taking a performance
 trace.

--- a/README.md
+++ b/README.md
@@ -993,7 +993,8 @@ instance. It shows a dialog asking for user permission.
 On Linux, automatic connection discovers both the standard `Brave-Browser`
 profile and the `Brave-Origin` profile used by Manjaro's `brave-origin-bin`
 package. When both profiles exist, it selects the one with an active remote
-debugging port.
+debugging marker (`DevToolsActivePort`). The subsequent connection attempt
+validates the marker contents and reports an error if it is stale.
 
 Clicking **Allow** results in the Brave DevTools MCP server opening
 [developers.chrome.com](http://developers.chrome.com) and taking a performance

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -18,6 +18,20 @@ let browserMode: 'launched' | 'connected' | undefined;
 
 export type Channel = 'release' | 'beta' | 'nightly';
 
+export function linuxBraveExecutableCandidates(channel: Channel): string[] {
+  const paths: Record<Channel, string[]> = {
+    release: [
+      'brave-browser',
+      'brave-browser-stable',
+      'brave-origin',
+      '/opt/brave-origin-bin/brave',
+    ],
+    beta: ['brave-browser-beta'],
+    nightly: ['brave-browser-nightly'],
+  };
+  return paths[channel];
+}
+
 // Heavy pages (e.g. Studio module dev bundles >100MB) cannot ack
 // `Network.enable` and other auto-attached domain calls within
 // puppeteer's default 180s. Once that fires, the CDP connection is
@@ -68,7 +82,7 @@ function makeTargetFilter(enableExtensions = false) {
   };
 }
 
-function resolveBraveExecutablePath(channel?: Channel): string {
+export function resolveBraveExecutablePath(channel?: Channel): string {
   const envPath = process.env['BRAVE_PATH'];
   if (envPath) {
     if (!fs.existsSync(envPath)) {
@@ -98,22 +112,31 @@ function resolveBraveExecutablePath(channel?: Channel): string {
   }
 
   if (platform === 'linux') {
-    const paths: Record<Channel, string[]> = {
-      release: ['brave-browser', 'brave-browser-stable'],
-      beta: ['brave-browser-beta'],
-      nightly: ['brave-browser-nightly'],
-    };
-    const candidates = paths[channel ?? 'release'];
+    const candidates = linuxBraveExecutableCandidates(channel ?? 'release');
     for (const candidate of candidates) {
-      try {
-        const resolvedPath = execSync(`which ${candidate}`, {
-          encoding: 'utf8',
-        }).trim();
-        if (resolvedPath) {
-          return resolvedPath;
+      if (path.isAbsolute(candidate)) {
+        try {
+          fs.accessSync(candidate, fs.constants.X_OK);
+          return candidate;
+        } catch {
+          // try next candidate
         }
-      } catch {
-        // try next candidate
+        continue;
+      }
+
+      for (const pathEntry of (process.env['PATH'] ?? '').split(
+        path.delimiter,
+      )) {
+        if (!pathEntry) {
+          continue;
+        }
+        const resolvedPath = path.join(pathEntry, candidate);
+        try {
+          fs.accessSync(resolvedPath, fs.constants.X_OK);
+          return resolvedPath;
+        } catch {
+          // try next PATH entry
+        }
       }
     }
     throw new Error(
@@ -188,7 +211,7 @@ function resolveBraveExecutablePath(channel?: Channel): string {
   throw new Error(`Unsupported platform: ${platform}`);
 }
 
-function resolveBraveUserDataDir(channel?: Channel): string {
+export function resolveBraveUserDataDir(channel?: Channel): string {
   const platform = os.platform();
   const home = os.homedir();
 
@@ -222,12 +245,24 @@ function resolveBraveUserDataDir(channel?: Channel): string {
   if (platform === 'linux') {
     const configDir =
       process.env['XDG_CONFIG_HOME'] ?? path.join(home, '.config');
-    const dirs: Record<Channel, string> = {
-      release: path.join(configDir, 'BraveSoftware', 'Brave-Browser'),
-      beta: path.join(configDir, 'BraveSoftware', 'Brave-Browser-Beta'),
-      nightly: path.join(configDir, 'BraveSoftware', 'Brave-Browser-Nightly'),
+    const dirs: Record<Channel, string[]> = {
+      release: [
+        path.join(configDir, 'BraveSoftware', 'Brave-Browser'),
+        path.join(configDir, 'BraveSoftware', 'Brave-Origin'),
+      ],
+      beta: [path.join(configDir, 'BraveSoftware', 'Brave-Browser-Beta')],
+      nightly: [path.join(configDir, 'BraveSoftware', 'Brave-Browser-Nightly')],
     };
-    return dirs[channel ?? 'release'];
+    const candidates = dirs[channel ?? 'release'];
+    return (
+      candidates.find(candidate => {
+        return fs.existsSync(path.join(candidate, 'DevToolsActivePort'));
+      }) ??
+      candidates.find(candidate => {
+        return fs.existsSync(candidate);
+      }) ??
+      candidates[0]
+    );
   }
 
   if (platform === 'win32') {

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -32,6 +32,18 @@ export function linuxBraveExecutableCandidates(channel: Channel): string[] {
   return paths[channel];
 }
 
+function isExecutableFile(candidate: string): boolean {
+  try {
+    if (!fs.statSync(candidate).isFile()) {
+      return false;
+    }
+    fs.accessSync(candidate, fs.constants.X_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 // Heavy pages (e.g. Studio module dev bundles >100MB) cannot ack
 // `Network.enable` and other auto-attached domain calls within
 // puppeteer's default 180s. Once that fires, the CDP connection is
@@ -115,11 +127,8 @@ export function resolveBraveExecutablePath(channel?: Channel): string {
     const candidates = linuxBraveExecutableCandidates(channel ?? 'release');
     for (const candidate of candidates) {
       if (path.isAbsolute(candidate)) {
-        try {
-          fs.accessSync(candidate, fs.constants.X_OK);
+        if (isExecutableFile(candidate)) {
           return candidate;
-        } catch {
-          // try next candidate
         }
         continue;
       }
@@ -131,11 +140,8 @@ export function resolveBraveExecutablePath(channel?: Channel): string {
           continue;
         }
         const resolvedPath = path.join(pathEntry, candidate);
-        try {
-          fs.accessSync(resolvedPath, fs.constants.X_OK);
+        if (isExecutableFile(resolvedPath)) {
           return resolvedPath;
-        } catch {
-          // try next PATH entry
         }
       }
     }

--- a/tests/browser-discovery.test.ts
+++ b/tests/browser-discovery.test.ts
@@ -72,6 +72,49 @@ describe(
       assert.strictEqual(resolveBraveExecutablePath('release'), executable);
     });
 
+    it('skips executable directories that have a browser candidate name', () => {
+      const binDirectory = temporaryDirectory();
+      fs.mkdirSync(path.join(binDirectory, 'brave-browser'), {mode: 0o755});
+      const executable = path.join(binDirectory, 'brave-origin');
+      fs.writeFileSync(executable, '#!/bin/sh\n');
+      fs.chmodSync(executable, 0o755);
+      delete process.env['BRAVE_PATH'];
+      process.env['PATH'] = binDirectory;
+
+      assert.strictEqual(resolveBraveExecutablePath('release'), executable);
+    });
+
+    it('skips regular browser candidates without execute permission', () => {
+      const binDirectory = temporaryDirectory();
+      fs.writeFileSync(
+        path.join(binDirectory, 'brave-browser'),
+        '#!/bin/sh\n',
+        {
+          mode: 0o644,
+        },
+      );
+      const executable = path.join(binDirectory, 'brave-origin');
+      fs.writeFileSync(executable, '#!/bin/sh\n');
+      fs.chmodSync(executable, 0o755);
+      delete process.env['BRAVE_PATH'];
+      process.env['PATH'] = binDirectory;
+
+      assert.strictEqual(resolveBraveExecutablePath('release'), executable);
+    });
+
+    it('accepts an executable symlink whose target is a regular file', () => {
+      const binDirectory = temporaryDirectory();
+      const target = path.join(binDirectory, 'brave-origin-bin');
+      const executable = path.join(binDirectory, 'brave-origin');
+      fs.writeFileSync(target, '#!/bin/sh\n');
+      fs.chmodSync(target, 0o755);
+      fs.symlinkSync(target, executable);
+      delete process.env['BRAVE_PATH'];
+      process.env['PATH'] = binDirectory;
+
+      assert.strictEqual(resolveBraveExecutablePath('release'), executable);
+    });
+
     it('uses the Brave-Origin profile when it is the installed release profile', () => {
       const configDirectory = temporaryDirectory();
       const originProfile = path.join(
@@ -85,7 +128,7 @@ describe(
       assert.strictEqual(resolveBraveUserDataDir('release'), originProfile);
     });
 
-    it('prefers the release profile with an active debugging port', () => {
+    it('prefers the release profile with a DevToolsActivePort marker', () => {
       const configDirectory = temporaryDirectory();
       const standardProfile = path.join(
         configDirectory,

--- a/tests/browser-discovery.test.ts
+++ b/tests/browser-discovery.test.ts
@@ -1,0 +1,111 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import assert from 'node:assert';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {afterEach, describe, it} from 'node:test';
+
+import {
+  linuxBraveExecutableCandidates,
+  resolveBraveExecutablePath,
+  resolveBraveUserDataDir,
+} from '../src/browser.js';
+
+const originalBravePath = process.env['BRAVE_PATH'];
+const originalPath = process.env['PATH'];
+const originalXdgConfigHome = process.env['XDG_CONFIG_HOME'];
+const temporaryDirectories: string[] = [];
+
+function temporaryDirectory(): string {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'brave-origin-'));
+  temporaryDirectories.push(directory);
+  return directory;
+}
+
+afterEach(() => {
+  if (originalBravePath === undefined) {
+    delete process.env['BRAVE_PATH'];
+  } else {
+    process.env['BRAVE_PATH'] = originalBravePath;
+  }
+  if (originalPath === undefined) {
+    delete process.env['PATH'];
+  } else {
+    process.env['PATH'] = originalPath;
+  }
+  if (originalXdgConfigHome === undefined) {
+    delete process.env['XDG_CONFIG_HOME'];
+  } else {
+    process.env['XDG_CONFIG_HOME'] = originalXdgConfigHome;
+  }
+  for (const directory of temporaryDirectories.splice(0)) {
+    fs.rmSync(directory, {recursive: true, force: true});
+  }
+});
+
+describe(
+  'Linux Brave Origin discovery',
+  {skip: os.platform() !== 'linux'},
+  () => {
+    it('includes the Manjaro brave-origin-bin executable locations', () => {
+      assert.deepStrictEqual(linuxBraveExecutableCandidates('release'), [
+        'brave-browser',
+        'brave-browser-stable',
+        'brave-origin',
+        '/opt/brave-origin-bin/brave',
+      ]);
+    });
+
+    it('finds the brave-origin executable on PATH', () => {
+      const binDirectory = temporaryDirectory();
+      const executable = path.join(binDirectory, 'brave-origin');
+      fs.writeFileSync(executable, '#!/bin/sh\n');
+      fs.chmodSync(executable, 0o755);
+      delete process.env['BRAVE_PATH'];
+      process.env['PATH'] = binDirectory;
+
+      assert.strictEqual(resolveBraveExecutablePath('release'), executable);
+    });
+
+    it('uses the Brave-Origin profile when it is the installed release profile', () => {
+      const configDirectory = temporaryDirectory();
+      const originProfile = path.join(
+        configDirectory,
+        'BraveSoftware',
+        'Brave-Origin',
+      );
+      fs.mkdirSync(originProfile, {recursive: true});
+      process.env['XDG_CONFIG_HOME'] = configDirectory;
+
+      assert.strictEqual(resolveBraveUserDataDir('release'), originProfile);
+    });
+
+    it('prefers the release profile with an active debugging port', () => {
+      const configDirectory = temporaryDirectory();
+      const standardProfile = path.join(
+        configDirectory,
+        'BraveSoftware',
+        'Brave-Browser',
+      );
+      const originProfile = path.join(
+        configDirectory,
+        'BraveSoftware',
+        'Brave-Origin',
+      );
+      fs.mkdirSync(standardProfile, {recursive: true});
+      fs.mkdirSync(originProfile, {recursive: true});
+      fs.writeFileSync(
+        path.join(originProfile, 'DevToolsActivePort'),
+        '9222\n',
+      );
+      process.env['XDG_CONFIG_HOME'] = configDirectory;
+
+      assert.strictEqual(resolveBraveUserDataDir('release'), originProfile);
+    });
+  },
+);


### PR DESCRIPTION
Manjaro's `brave-origin-bin` package does not use the standard Linux Brave names. Version `1:1.92.139-1` installs a `brave-origin` wrapper, its browser binary at `/opt/brave-origin-bin/brave`, and its profile under `BraveSoftware/Brave-Origin`. Before this change, launching required `BRAVE_PATH`, and `--autoConnect` only checked `Brave-Browser`.

This change:

- discovers `brave-origin` on `PATH` and `/opt/brave-origin-bin/brave` for the release channel;
- discovers the Linux `Brave-Origin` profile for automatic connection;
- prefers a release profile containing `DevToolsActivePort` when both standard Brave and Brave Origin profiles exist;
- requires PATH and absolute candidates to resolve to executable regular files (including symlinks to files);
- documents `DevToolsActivePort` marker precedence and adds filesystem-backed regression tests for directories, non-executable files, executable symlinks, and competing profiles.

Validation:

- `npm run format`
- `npm run check-format`
- `npm run test tests/browser-discovery.test.ts`

The full local suite reached three pre-existing CLI daemon assertions when run against this Brave Origin build (`list_pages`, screenshot, and performance trace found no initial page). The focused discovery suite, TypeScript build, lint, and formatting checks pass. Hosted CI installs standard Brave independently on Linux, macOS, and Windows.
